### PR TITLE
Prepare fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
+> A fork of [snarkdown](https://github.com/developit/snarkdown) with [some fixes applied](https://github.com/developit/snarkdown/compare/master...bpmn-io:master).
+
+
 <p align="center">
   <img src="https://cdn.jsdelivr.net/emojione/assets/svg/1f63c.svg" width="256" height="256" alt="Snarkdown">
 </p>
 <h1 align="center">
   Snarkdown
-  <a href="https://www.npmjs.org/package/snarkdown">
-    <img src="https://img.shields.io/npm/v/snarkdown.svg?style=flat" alt="npm">
+  <a href="https://www.npmjs.org/package/@bpmn-io/snarkdown">
+    <img src="https://img.shields.io/npm/v/@bpmn-io/snarkdown.svg?style=flat" alt="npm">
   </a>
 </h1>
 
@@ -33,10 +36,10 @@ It's designed to be as minimal as possible, for constrained use-cases where a fu
 
 Snarkdown exports a single function, which parses a string of Markdown and returns a String of HTML. Couldn't be simpler.
 
-The snarkdown module is available in [every module format](https://unpkg.com/snarkdown/dist/) you'd ever need: ES Modules, CommonJS, UMD...
+The snarkdown module is available in [every module format](https://unpkg.com/@bpmn-io/snarkdown/dist/) you'd ever need: ES Modules, CommonJS, UMD...
 
 ```js
-import snarkdown from 'snarkdown';
+import snarkdown from '@bpmn-io/snarkdown';
 
 let md = '_this_ is **easy** to `use`.';
 let html = snarkdown(md);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "snarkdown",
+  "name": "@bpmn-io/snarkdown",
   "description": "Transform Markdown into HTML.",
   "version": "2.0.0",
   "main": "./dist/snarkdown.js",
@@ -15,6 +15,9 @@
     "prepublish": "npm run -s build",
     "release": "npm run -s build && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "authors": [
     "Jason Miller <jason@developit.ca>"
   ],
@@ -23,8 +26,8 @@
     "dist",
     "snarkdown.d.ts"
   ],
-  "homepage": "https://github.com/developit/snarkdown",
-  "repository": "developit/snarkdown",
+  "homepage": "https://github.com/bpmn-io/snarkdown",
+  "repository": "bpmn-io/snarkdown",
   "license": "MIT",
   "keywords": [
     "markdown",

--- a/snarkdown.d.ts
+++ b/snarkdown.d.ts
@@ -1,4 +1,4 @@
-declare module "snarkdown" {
+declare module "@bpmn-io/snarkdown" {
   interface Links {
     [index: string]: string;
   }


### PR DESCRIPTION
Prepares a (temporary) fork of snarkdown to be able to publish fixes, i.e. https://github.com/bpmn-io/snarkdown/pull/1.